### PR TITLE
Updates for Orleans 1.0.0 release.

### DIFF
--- a/Orleans.Serialization.Newtonsoft.Json/Orleans.Serialization.Newtonsoft.Json.csproj
+++ b/Orleans.Serialization.Newtonsoft.Json/Orleans.Serialization.Newtonsoft.Json.csproj
@@ -32,13 +32,10 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Orleans">
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
-    </Reference>
-    <Reference Include="OrleansProviderInterfaces">
-      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviderInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="OrleansProviders">
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviders.dll</HintPath>

--- a/Orleans.Serialization.Newtonsoft.Json/packages.config
+++ b/Orleans.Serialization.Newtonsoft.Json/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
 </packages>

--- a/Orleans.Serialization.RavenDB.Json/Orleans.Serialization.RavenDB.Json.csproj
+++ b/Orleans.Serialization.RavenDB.Json/Orleans.Serialization.RavenDB.Json.csproj
@@ -39,9 +39,6 @@
     <Reference Include="Orleans">
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\Orleans.dll</HintPath>
     </Reference>
-    <Reference Include="OrleansProviderInterfaces">
-      <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviderInterfaces.dll</HintPath>
-    </Reference>
     <Reference Include="OrleansProviders">
       <HintPath>$(OrleansSDK)\Binaries\OrleansServer\OrleansProviders.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Updated Newtonsoft.JSON to 6.0.8; removed reference to Orleans.ProviderInterfaces as that .dll was removed with the Orleans 1.0.0 release.

I was working with https://github.com/OrleansContrib/OrleansBlobStorageProvider so I got down in here, too, and figured I'd submit a quick update. I specifically did not update the RavenDB NuGet package because I have no reason to use/test it... you may wish to, as they've gone from 2.5.xxxx to a stable 3.0.xxxx release.

Thanks!
Scott
Seattle, WA, USA
